### PR TITLE
Remove use of `apt-key`

### DIFF
--- a/dcap-libs/action.yaml
+++ b/dcap-libs/action.yaml
@@ -14,8 +14,9 @@ runs:
       run:
         DCAP_VERSION=${{ inputs.version }}
         source /etc/lsb-release &&
-        echo "deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu $DISTRIB_CODENAME main" | sudo tee /etc/apt/sources.list.d/intel-sgx.list &&
-        wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add - &&
+        sudo mkdir -p /etc/apt/keyrings &&
+        wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | gpg --dearmor | sudo tee /etc/apt/keyrings/intel-sgx.gpg > /dev/null &&
+        echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/intel-sgx.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu $DISTRIB_CODENAME main" | sudo tee /etc/apt/sources.list.d/intel-sgx.list
         sudo apt-get update &&
         sudo apt-get install -y libsgx-dcap-ql${DCAP_VERSION:+"=${DCAP_VERSION}"} libsgx-dcap-ql-dev${DCAP_VERSION:+"=${DCAP_VERSION}"} &&
         sudo apt-get install -y libsgx-dcap-quote-verify${DCAP_VERSION:+"=${DCAP_VERSION}"} libsgx-dcap-quote-verify-dev${DCAP_VERSION:+"=${DCAP_VERSION}"}


### PR DESCRIPTION
`apt-key ` will last be available in debian 11 and ubuntu 22.04.
This changes to use a gpg key only for the intel-sgx repositories